### PR TITLE
Move OptionsButton to offset from ZoomOut button

### DIFF
--- a/MetaMap/MetaMap.xml
+++ b/MetaMap/MetaMap.xml
@@ -1534,7 +1534,7 @@
 		<Anchors>
 			<Anchor	point="CENTER" relativeTo="WorldMapZoomOutButton"	relativePoint="CENTER">
 				<Offset>
-					<AbsDimension	x="0"	y="0"/>
+					<AbsDimension	x="200"	y="0"/>
 				</Offset>
 			</Anchor>
 		</Anchors>


### PR DESCRIPTION
Because when you also [ShaguTweaks ](https://github.com/shagu/ShaguTweaks/) addon it would add the ZoomOut button again, overlapping with the OptionsButton.

To fix this, I moved the button a to the right.

Before:
![image](https://github.com/laytya/Metamap-vanilla/assets/2750503/6ecdc3bb-0697-40b4-8f65-ce8e05194d92)

After:
![image](https://github.com/laytya/Metamap-vanilla/assets/2750503/37793995-7235-418f-b895-2784bf1fe1a8)


Thoughts? :)